### PR TITLE
修復影片顯示問題

### DIFF
--- a/score_following_game/environment/render_utils.py
+++ b/score_following_game/environment/render_utils.py
@@ -8,8 +8,14 @@ def prepare_spec_for_render(spec, resz_spec=4, transform_to_bgr=True):
 
     if transform_to_bgr:
         spec_prep = spec[0][::-1, :]
-        spec_prep = cv2.resize(spec_prep, (spec[0].shape[1] * resz_spec, spec[0].shape[0] * resz_spec))
-        spec_prep = plt.cm.viridis(spec_prep)[:, :, 0:3]
+        spec_prep = cv2.resize(
+            spec_prep,
+            (spec[0].shape[1] * resz_spec, spec[0].shape[0] * resz_spec),
+        )
+        spec_norm = spec_prep.astype(np.float32)
+        if spec_norm.max() > 1.0:
+            spec_norm = spec_norm / 255.0
+        spec_prep = plt.cm.viridis(spec_norm)[:, :, 0:3]
         spec_prep = (spec_prep * 255).astype(np.uint8)
         spec_transformed = cv2.cvtColor(spec_prep, cv2.COLOR_RGB2BGR)
     else:
@@ -36,6 +42,7 @@ def prepare_sheet_for_render(sheet,  resz_x=8, resz_y=4, transform_to_bgr=True):
 def write_text(text, position, img, font_face=cv2.FONT_HERSHEY_SIMPLEX, color=(0, 0, 0)):
 
     text_size = cv2.getTextSize(text, fontFace=font_face, fontScale=0.6, thickness=1)[0]
-    text_org = ((img.shape[1] - text_size[0] - 5), (img.shape[1]//2 + position * text_size[1] + 3))
-    cv2.putText(img, text, text_org, fontFace=font_face, fontScale=0.6, color=color, thickness=1)
+    x = img.shape[1] - text_size[0] - 5
+    y = position + text_size[1]
+    cv2.putText(img, text, (x, y), fontFace=font_face, fontScale=0.6, color=color, thickness=1)
 


### PR DESCRIPTION
## Summary
- normalize the spectrogram before applying colormap to show details correctly
- adjust text rendering so debug info is placed properly on screen

## Testing
- `python -m py_compile score_following_game-tismir-m3/score_following_game/environment/render_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68610f8d9c08832082fc841b2d000e0a