### PR TITLE
Allow passing sound font path for evaluation

### DIFF
--- a/score_following_game/evaluate_agent.py
+++ b/score_following_game/evaluate_agent.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
 
     # load game config
     config = load_game_config(args.game_config)
+    sf2_path = config.get("sound_font", None)
 
     # set agent type ('human', 'optimal') optimal currently not supported
     agent_type = render_mode
@@ -53,7 +54,8 @@ if __name__ == "__main__":
     agent = initialize_trained_agent(model, use_cuda=use_cuda, deterministic=False)
 
     # initialize evaluation pools
-    evaluation_pools = get_data_pools(config, directory=args.data_set, real_perf=args.real_perf)
+    evaluation_pools = get_data_pools(config, directory=args.data_set, real_perf=args.real_perf,
+                                      sf2_path=sf2_path)
 
     # set verbosity level
     verbose = args.trials == 1

--- a/score_following_game/experiment.py
+++ b/score_following_game/experiment.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
 
     # load game config
     config = load_game_config(args.game_config)
+    sf2_path = config.get("sound_font", None)
 
     # initialize song cache, producer and data pools
     CACHE_SIZE = 50
@@ -108,7 +109,8 @@ if __name__ == '__main__':
         model.cuda()
 
     # initialize model evaluation
-    evaluation_pools = get_data_pools(config, directory=args.eval_set, real_perf=args.real_perf)
+    evaluation_pools = get_data_pools(config, directory=args.eval_set, real_perf=args.real_perf,
+                                      sf2_path=sf2_path)
 
     # + : Evaluator 類別預期在其內部 (evaluation/evaluation.py) 已適配 Gymnasium API
     evaluator = Evaluator(env_fnc, evaluation_pools, config=config, trials=args.eval_trials, render_mode=None)


### PR DESCRIPTION
## Summary
- pipe `sound_font` entry from YAML down to FluidSynth
- update `evaluate_agent.py` and `experiment.py` to supply `sf2_path`
- extend datapool creation to carry `sf2_path` into score synthesis

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871302aa7dc8320bd0ec7e0d5af2d78